### PR TITLE
Update to Django 6.0 and Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0
+
+- Added support for Django 6.0.
+- Bumped minimum Python version to 3.12 (required by Django 6.0).
+- Fixed syntax warnings in tests for Python 3.12+.
+- Cleaned up resource leaks in test suite.
+
 ## 0.3.0
 
 - Migrated from `poetry` to `uv`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "django-typescript-routes"
-version = "0.3.0"
+version = "0.4.0"
 description = "Generate typescript routes from a Django URLconf"
 authors = [{ name = "Justin Duke", email = "justin@buttondown.email" }]
-requires-python = "~=3.11"
+requires-python = ">=3.12"
 readme = "README.md"
 license = "MIT"
-dependencies = ["Django>=5,<6"]
+dependencies = ["Django>=5.1,<7"]
 
 [project.urls]
 Repository = "https://github.com/buttondown-email/django-typescript-routes"

--- a/tests/logic--test-monkeypatching.py
+++ b/tests/logic--test-monkeypatching.py
@@ -1,14 +1,18 @@
 import re
 
 import django
+
 from typescript_routes.lib.logic import generate_routes
+
 
 def test_handles_monkeypatching() -> None:
     # See https://github.com/wrabit/django-cotton/issues/299.
 
     from django.template import base
+
     base.tag_re = re.compile(base.tag_re.pattern, re.DOTALL)
 
     django.setup()
 
-    assert generate_routes("tests.urls_basic", []) == open("tests/fixtures/basic.ts").read()
+    with open("tests/fixtures/basic.ts") as f:
+        assert generate_routes("tests.urls_basic", []) == f.read()

--- a/tests/logic--test.py
+++ b/tests/logic--test.py
@@ -1,21 +1,28 @@
 from django.urls import get_resolver
+
 from typescript_routes.lib.logic import extract_routes, generate_routes
+
 
 def test_extract_routes_smoke() -> None:
     resolver = get_resolver("tests.urls")
     assert list(extract_routes(resolver, [])) == []
 
+
 def test_generate_routes_smoke() -> None:
     import django
+
     django.setup()
 
-    assert generate_routes("tests.urls", []) == open("tests/fixtures/empty.ts").read()
+    with open("tests/fixtures/empty.ts") as f:
+        assert generate_routes("tests.urls", []) == f.read()
 
 
 def test_generate_routes_basic() -> None:
     import django
+
     django.setup()
 
-    expectation = open("tests/fixtures/basic.ts").read()
+    with open("tests/fixtures/basic.ts") as f:
+        expectation = f.read()
     reality = generate_routes("tests.urls_basic", [])
     assert reality == expectation, f"Expected:\n{expectation}\n\nGot:\n{reality}"

--- a/tests/urls_basic.py
+++ b/tests/urls_basic.py
@@ -4,5 +4,5 @@ urlpatterns = [
     path("foo/<int:bar>/", lambda: None, name="foo"),
     path("baz/<str:bar>/", lambda: None, name="baz"),
     path("qux/<username>/", lambda: None, name="qux"),
-    re_path("zod/(?P<username>\w+)/$/", lambda: None, name="zod"),
+    re_path(r"zod/(?P<username>\w+)/$/", lambda: None, name="zod"),
 ]

--- a/typescript_routes/lib/logic.py
+++ b/typescript_routes/lib/logic.py
@@ -67,5 +67,7 @@ def generate_routes(urlconf: str, denylist: list[str]) -> str:
     routes = extract_routes(resolver, denylist)
     rendered_string = render_to_string("urls.ts.template", {"routes": routes})
     # Remove all empty lines injected via the template.
-    rendered_string = "\n".join(line for line in rendered_string.split("\n") if line.strip())
+    rendered_string = "\n".join(
+        line for line in rendered_string.split("\n") if line.strip()
+    )
     return rendered_string.strip() + "\n"

--- a/typescript_routes/management/commands/generate_typescript_routes.py
+++ b/typescript_routes/management/commands/generate_typescript_routes.py
@@ -1,10 +1,10 @@
+from django.core.management.base import BaseCommand, CommandParser
+
 from typescript_routes.lib.logic import generate_routes
-from django.core.management.base import BaseCommand
-from django.core.management.base import CommandParser
 
 
 class Command(BaseCommand):
-    help = 'Prints a static TypeScript file that can be used to reverse Django URLs.'
+    help = "Prints a static TypeScript file that can be used to reverse Django URLs."
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("-u", "--urlconf", type=str)

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,14 @@
 version = 1
-revision = 2
-requires-python = ">=3.11, <4"
+revision = 3
+requires-python = ">=3.12"
 
 [[package]]
 name = "asgiref"
-version = "3.8.1"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/38/b3395cc9ad1b56d2ddac9970bc8f4141312dbaec28bc7c218b0dfafd0f42/asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590", size = 35186, upload-time = "2024-03-22T14:39:36.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/b9/4db2509eabd14b4a8c71d1b24c8d5734c52b8560a7b1e1a8b56c8d25568b/asgiref-3.11.0.tar.gz", hash = "sha256:13acff32519542a1736223fb79a715acdebe24286d98e8b164a73085f40da2c4", size = 37969, upload-time = "2025-11-19T15:32:20.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/e3/893e8757be2612e6c266d9bb58ad2e3651524b5b40cf56761e985a28b13e/asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47", size = 23828, upload-time = "2024-03-22T14:39:34.521Z" },
+    { url = "https://files.pythonhosted.org/packages/91/be/317c2c55b8bbec407257d45f5c8d1b6867abc76d12043f2d3d58c538a4ea/asgiref-3.11.0-py3-none-any.whl", hash = "sha256:1db9021efadb0d9512ce8ffaf72fcef601c7b73a8807a1bb2ef143dc6b14846d", size = 24096, upload-time = "2025-11-19T15:32:19.004Z" },
 ]
 
 [[package]]
@@ -22,21 +22,21 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.1.2"
+version = "6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/e5/a06e20c963b280af4aa9432bc694fbdeb1c8df9e28c2ffd5fbb71c4b1bec/Django-5.1.2.tar.gz", hash = "sha256:bd7376f90c99f96b643722eee676498706c9fd7dc759f55ebfaf2c08ebcdf4f0", size = 10711674, upload-time = "2024-10-08T14:53:12.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/75/19762bfc4ea556c303d9af8e36f0cd910ab17dff6c8774644314427a2120/django-6.0.tar.gz", hash = "sha256:7b0c1f50c0759bbe6331c6a39c89ae022a84672674aeda908784617ef47d8e26", size = 10932418, upload-time = "2025-12-03T16:26:21.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/b8/f205f2b8c44c6cdc555c4f56bbe85ceef7f67c0cf1caa8abe078bb7e32bd/Django-5.1.2-py3-none-any.whl", hash = "sha256:f11aa87ad8d5617171e3f77e1d5d16f004b79a2cf5d2e1d2b97a6a1f8e9ba5ed", size = 8276058, upload-time = "2024-10-08T14:53:05.58Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ae/f19e24789a5ad852670d6885f5480f5e5895576945fcc01817dfd9bc002a/django-6.0-py3-none-any.whl", hash = "sha256:1cc2c7344303bbfb7ba5070487c17f7fc0b7174bbb0a38cebf03c675f5f19b6d", size = 8339181, upload-time = "2025-12-03T16:26:16.231Z" },
 ]
 
 [[package]]
 name = "django-typescript-routes"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -49,7 +49,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "django", specifier = ">=5,<6" }]
+requires-dist = [{ name = "django", specifier = ">=5.1,<7" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Bumped version to 0.4.0. Added support for Django 6.0. Updated minimum Python version to 3.12. Fixed syntax warnings in tests for Python 3.12+.